### PR TITLE
Changed server display_init function to include a full JSON object from the Service

### DIFF
--- a/malachi_server.py
+++ b/malachi_server.py
@@ -59,7 +59,7 @@ class MalachiServer():
     async def display_init(self, websocket):
         await websocket.send(json.dumps({
             "action" : "update.service-overview-update", 
-            "params" : json.loads(self.s.to_JSON_simple())
+            "params" : json.loads(self.s.to_JSON_full())
             }))
 
     async def responder(self, websocket, path):


### PR DESCRIPTION
This is simply for the sake of the malachi app since the stage view (which will connect to /display on server) needs to know initially all of the data present from the service to initialise local state.