### PR TITLE
Added requirements.txt to simplify install process

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+websockets
+websocket-client
+requests
+mss
+opencv-python
+Pillow


### PR DESCRIPTION
Instead of installing each dependencies, as listed within the wiki individually, just run...

```
pip install -r requirements.txt
```

(side note - this works immediately on Mac OS Mojave)

👍